### PR TITLE
feat: add gdptools coordinate fields to dataset registry schema

### DIFF
--- a/src/hydro_param/data_access.py
+++ b/src/hydro_param/data_access.py
@@ -57,7 +57,13 @@ def _cell_sizes_meters(
     return dy_m, dx_m
 
 
-def derive_slope(elevation: xr.DataArray, method: str = "horn") -> xr.DataArray:
+def derive_slope(
+    elevation: xr.DataArray,
+    method: str = "horn",
+    *,
+    x_coord: str = "x",
+    y_coord: str = "y",
+) -> xr.DataArray:
     """Compute slope in degrees from an elevation DataArray.
 
     Uses Horn (1981) method via numpy.gradient.
@@ -65,9 +71,13 @@ def derive_slope(elevation: xr.DataArray, method: str = "horn") -> xr.DataArray:
     Parameters
     ----------
     elevation : xr.DataArray
-        2-D elevation raster with y/x coordinates.
+        2-D elevation raster with spatial coordinates.
     method : str
         Derivation method. Only ``"horn"`` is supported.
+    x_coord : str
+        Name of the x coordinate dimension in the DataArray.
+    y_coord : str
+        Name of the y coordinate dimension in the DataArray.
 
     Returns
     -------
@@ -78,8 +88,8 @@ def derive_slope(elevation: xr.DataArray, method: str = "horn") -> xr.DataArray:
         raise ValueError(f"Unsupported slope method: {method}")
 
     elev = elevation.values.astype(np.float64)
-    y_coords = elevation.coords["y"].values
-    x_coords = elevation.coords["x"].values
+    y_coords = elevation.coords[y_coord].values
+    x_coords = elevation.coords[x_coord].values
 
     has_crs = hasattr(elevation, "rio") and elevation.rio.crs
     is_geographic = has_crs and elevation.rio.crs.is_geographic
@@ -95,15 +105,25 @@ def derive_slope(elevation: xr.DataArray, method: str = "horn") -> xr.DataArray:
     return result
 
 
-def derive_aspect(elevation: xr.DataArray, method: str = "horn") -> xr.DataArray:
+def derive_aspect(
+    elevation: xr.DataArray,
+    method: str = "horn",
+    *,
+    x_coord: str = "x",
+    y_coord: str = "y",
+) -> xr.DataArray:
     """Compute aspect in degrees (clockwise from north) from elevation.
 
     Parameters
     ----------
     elevation : xr.DataArray
-        2-D elevation raster with y/x coordinates.
+        2-D elevation raster with spatial coordinates.
     method : str
         Derivation method. Only ``"horn"`` is supported.
+    x_coord : str
+        Name of the x coordinate dimension in the DataArray.
+    y_coord : str
+        Name of the y coordinate dimension in the DataArray.
 
     Returns
     -------
@@ -114,8 +134,8 @@ def derive_aspect(elevation: xr.DataArray, method: str = "horn") -> xr.DataArray
         raise ValueError(f"Unsupported aspect method: {method}")
 
     elev = elevation.values.astype(np.float64)
-    y_coords = elevation.coords["y"].values
-    x_coords = elevation.coords["x"].values
+    y_coords = elevation.coords[y_coord].values
+    x_coords = elevation.coords[x_coord].values
 
     has_crs = hasattr(elevation, "rio") and elevation.rio.crs
     is_geographic = has_crs and elevation.rio.crs.is_geographic

--- a/src/hydro_param/pipeline.py
+++ b/src/hydro_param/pipeline.py
@@ -169,7 +169,12 @@ def _process_batch(
             derive_fn = DERIVATION_FUNCTIONS.get(var_spec.name)
             if derive_fn is None:
                 raise ValueError(f"No derivation function for '{var_spec.name}'")
-            da = derive_fn(source_da, method=var_spec.method)
+            da = derive_fn(
+                source_da,
+                method=var_spec.method,
+                x_coord=entry.x_coord,
+                y_coord=entry.y_coord,
+            )
         else:
             # Raw variable: fetch directly
             # TODO: Pass var_spec.band to fetch routine for multi-band datasets
@@ -196,6 +201,9 @@ def _process_batch(
             engine=config.processing.engine,
             statistics=ds_req.statistics,
             categorical=categorical,
+            source_crs=entry.crs,
+            x_coord=entry.x_coord,
+            y_coord=entry.y_coord,
         )
         results[var_spec.name] = df
 


### PR DESCRIPTION
## Summary

- Add `x_coord`, `y_coord`, `t_coord` fields to `DatasetEntry` to match gdptools `UserTiffData`/`UserCatData` constructor parameters (`source_x_coord`, `source_y_coord`, `source_t_coord`)
- `x_coord`/`y_coord` default to `"x"`/`"y"` for backward compatibility
- `t_coord` is optional (`None`), validated as required when `temporal=true`
- Update `datasets.yml` with explicit coordinate names (e.g., POLARIS uses `lon`/`lat`)
- Add 4 new tests for coordinate defaults, custom names, and temporal validation
- All 70 tests passing

## Test plan

- [x] `test_coordinate_defaults` — verifies x/y default to "x"/"y", t_coord defaults to None
- [x] `test_custom_coordinate_names` — verifies lon/lat override works
- [x] `test_temporal_requires_t_coord` — verifies validation error when temporal=true without t_coord
- [x] `test_temporal_with_t_coord_valid` — verifies temporal dataset with t_coord passes
- [x] `test_load_real_registry` — verifies configs/datasets.yml loads with new fields
- [x] Full test suite (70/70 passing)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)