### PR TITLE
feat: implement step 5 soils zonal stats

### DIFF
--- a/src/hydro_param/derivations/pywatershed.py
+++ b/src/hydro_param/derivations/pywatershed.py
@@ -622,6 +622,8 @@ class PywatershedDerivation:
     # Step 5: Soils zonal stats
     # ------------------------------------------------------------------
 
+    _SOIL_RECHR_MAX_FRAC_DEFAULT: float = 0.4
+
     def _derive_soils(self, ctx: DerivationContext, ds: xr.Dataset) -> xr.Dataset:
         """Step 5: Derive soil parameters from gNATSGO/STATSGO2 zonal stats.
 
@@ -645,6 +647,12 @@ class PywatershedDerivation:
                 dims="nhru",
                 attrs={"units": "integer", "long_name": "PRMS soil type (1=sand, 2=loam, 3=clay)"},
             )
+        else:
+            logger.warning(
+                "Skipping soil_type derivation (step 5): no soil texture data "
+                "found in SIR. Expected soil_texture_frac_* columns or "
+                "soil_texture/soil_texture_majority variable."
+            )
 
         # --- soil_moist_max ---
         if "awc_mm_mean" in sir:
@@ -656,30 +664,46 @@ class PywatershedDerivation:
                 dims="nhru",
                 attrs={"units": "inches", "long_name": "Maximum soil moisture capacity"},
             )
+        else:
+            logger.warning(
+                "Skipping soil_moist_max derivation (step 5): 'awc_mm_mean' not found in SIR."
+            )
 
         # --- soil_rechr_max_frac ---
         if "soil_type" in ds:
             nhru = len(ds["soil_type"])
             ds["soil_rechr_max_frac"] = xr.DataArray(
-                np.full(nhru, 0.4),
+                np.full(nhru, self._SOIL_RECHR_MAX_FRAC_DEFAULT),
                 dims="nhru",
                 attrs={
                     "units": "decimal_fraction",
                     "long_name": "Fraction of soil moisture in recharge zone",
                 },
             )
+            logger.debug(
+                "soil_rechr_max_frac set to default %.2f for %d HRUs "
+                "(no soil layer data available)",
+                self._SOIL_RECHR_MAX_FRAC_DEFAULT,
+                nhru,
+            )
 
         return ds
 
     def _compute_soil_type(self, sir: xr.Dataset, ctx: DerivationContext) -> np.ndarray | None:
         """Compute PRMS soil_type from SIR soil texture data."""
+        # Check data availability before loading lookup table
+        prefix = "soil_texture_frac_"
+        fraction_vars = sorted(str(v) for v in sir.data_vars if str(v).startswith(prefix))
+        has_single = any(c in sir for c in ("soil_texture", "soil_texture_majority"))
+
+        if len(fraction_vars) < 2 and not has_single:
+            return None
+
         tables_dir = ctx.resolved_lookup_tables_dir
         soil_table = self._load_lookup_table("soil_texture_to_prms_type", tables_dir)
         mapping = soil_table["mapping"]
 
         # Try fraction columns first
-        prefix = "soil_texture_frac_"
-        fraction_vars = sorted(str(v) for v in sir.data_vars if str(v).startswith(prefix))
         if len(fraction_vars) >= 2:
             class_names: list[str] = []
             valid_vars: list[str] = []
@@ -693,6 +717,14 @@ class PywatershedDerivation:
 
             if len(valid_vars) >= 2:
                 fractions = np.column_stack([sir[v].values for v in valid_vars])
+                nan_mask = np.any(np.isnan(fractions), axis=1)
+                if np.any(nan_mask):
+                    logger.warning(
+                        "soil_type: %d/%d HRU(s) have NaN soil texture fractions; "
+                        "argmax result may be unreliable for those HRUs",
+                        int(np.sum(nan_mask)),
+                        len(fractions),
+                    )
                 majority_idx = np.argmax(fractions, axis=1)
                 majority_names = [class_names[i] for i in majority_idx]
                 return np.array([mapping[name] for name in majority_names])
@@ -701,7 +733,24 @@ class PywatershedDerivation:
         for candidate in ("soil_texture", "soil_texture_majority"):
             if candidate in sir:
                 texture_values = sir[candidate].values
-                return np.array([mapping.get(str(v), 2) for v in texture_values])
+                result = []
+                unknown_values: set[str] = set()
+                for v in texture_values:
+                    key = str(v)
+                    if key in mapping:
+                        result.append(mapping[key])
+                    else:
+                        unknown_values.add(key)
+                        result.append(2)  # default to loam
+                if unknown_values:
+                    logger.warning(
+                        "soil_type: %d HRU(s) have unrecognized texture class(es) "
+                        "%s in '%s'; defaulting to loam (soil_type=2)",
+                        sum(1 for val in texture_values if str(val) in unknown_values),
+                        sorted(unknown_values),
+                        candidate,
+                    )
+                return np.array(result)
 
         return None
 

--- a/tests/test_pywatershed_derivation.py
+++ b/tests/test_pywatershed_derivation.py
@@ -269,6 +269,66 @@ class TestDeriveSoils:
         # clay -> 3, sand -> 1, loam -> 2
         np.testing.assert_array_equal(ds["soil_type"].values, [3, 1, 2])
 
+    def test_soil_texture_majority_fallback(self, derivation: PywatershedDerivation) -> None:
+        """Falls back to soil_texture_majority when soil_texture absent."""
+        sir = xr.Dataset(
+            {
+                "soil_texture_majority": ("nhm_id", np.array(["sand", "clay"])),
+                "awc_mm_mean": ("nhm_id", np.array([50.0, 80.0])),
+            },
+            coords={"nhm_id": [1, 2]},
+        )
+        ctx = DerivationContext(sir=sir, fabric_id_field="nhm_id")
+        ds = derivation.derive(ctx)
+        assert "soil_type" in ds
+        np.testing.assert_array_equal(ds["soil_type"].values, [1, 3])
+
+    def test_unknown_texture_defaults_to_loam(self, derivation: PywatershedDerivation) -> None:
+        """Unrecognized texture class defaults to loam (soil_type=2) with warning."""
+        sir = xr.Dataset(
+            {
+                "soil_texture": ("nhm_id", np.array(["sand", "organic", "clay"])),
+                "awc_mm_mean": ("nhm_id", np.array([50.0, 70.0, 80.0])),
+            },
+            coords={"nhm_id": [1, 2, 3]},
+        )
+        ctx = DerivationContext(sir=sir, fabric_id_field="nhm_id")
+        ds = derivation.derive(ctx)
+        # sand -> 1, organic (unknown) -> 2 (loam default), clay -> 3
+        np.testing.assert_array_equal(ds["soil_type"].values, [1, 2, 3])
+
+    def test_fraction_columns_with_unknown_class_filtered(
+        self, derivation: PywatershedDerivation
+    ) -> None:
+        """Fraction columns with names not in lookup table are filtered out."""
+        sir = xr.Dataset(
+            {
+                "soil_texture_frac_sand": ("nhm_id", np.array([0.6, 0.2])),
+                "soil_texture_frac_loam": ("nhm_id", np.array([0.3, 0.7])),
+                "soil_texture_frac_bogus": ("nhm_id", np.array([0.1, 0.1])),
+                "awc_mm_mean": ("nhm_id", np.array([50.0, 80.0])),
+            },
+            coords={"nhm_id": [1, 2]},
+        )
+        ctx = DerivationContext(sir=sir, fabric_id_field="nhm_id")
+        ds = derivation.derive(ctx)
+        assert "soil_type" in ds
+        # sand=0.6 > loam=0.3 -> 1; loam=0.7 > sand=0.2 -> 2
+        np.testing.assert_array_equal(ds["soil_type"].values, [1, 2])
+
+    def test_soil_moist_max_without_soil_type(self, derivation: PywatershedDerivation) -> None:
+        """soil_moist_max produced even when no texture data (soil_type absent)."""
+        sir = xr.Dataset(
+            {"awc_mm_mean": ("nhm_id", np.array([100.0]))},
+            coords={"nhm_id": [1]},
+        )
+        ctx = DerivationContext(sir=sir, fabric_id_field="nhm_id")
+        ds = derivation.derive(ctx)
+        assert "soil_moist_max" in ds
+        assert "soil_type" not in ds
+        # soil_rechr_max_frac gates on soil_type
+        assert "soil_rechr_max_frac" not in ds
+
 
 class TestApplyLookupTables:
     """Tests for step 8: lookup table application."""


### PR DESCRIPTION
## Summary
- New `_derive_soils()` step in `PywatershedDerivation`
- Produces `soil_type` (1=sand, 2=loam, 3=clay), `soil_moist_max` (inches), `soil_rechr_max_frac`
- Supports texture fraction columns (majority via argmax) and single-value fallback
- Uses existing `soil_texture_to_prms_type.yml` lookup table

Closes #87
Part of #83

## Test plan
- [x] Majority from fraction columns (sand/loam/clay)
- [x] Reclassification to PRMS soil_type (1/2/3)
- [x] soil_moist_max from AWC (mm → inches conversion)
- [x] soil_moist_max clipped to [0.5, 20.0] inches
- [x] soil_rechr_max_frac defaults to 0.4
- [x] Single texture fallback
- [x] Missing SIR vars → graceful skip
- [x] No regressions (544 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)