### PR TITLE
fix: resolve SIR variable naming mismatch in pywatershed derivation

### DIFF
--- a/src/hydro_param/derivations/pywatershed.py
+++ b/src/hydro_param/derivations/pywatershed.py
@@ -1507,10 +1507,12 @@ class PywatershedDerivation:
             if not fraction_vars:
                 continue
 
-            # Extract class codes from suffixes
+            # Extract class codes from suffixes.  Fraction values are
+            # collected eagerly so that file-level datasets can be released
+            # immediately and multiple year-suffixed files don't overwrite
+            # each other.
             class_codes: list[int] = []
-            valid_vars: list[str] = []
-            inner_ds: xr.Dataset | None = None
+            fractions_list: list[np.ndarray] = []
             for v in fraction_vars:
                 suffix = v[len(prefix) :]
                 try:
@@ -1525,18 +1527,13 @@ class PywatershedDerivation:
 
                 if code > 95:
                     # Suffix looks like a year (e.g. 2021), not an NLCD class.
-                    # Try loading the inner columns from the backing file.
-                    if not hasattr(sir, "load_dataset"):
-                        logger.debug(
-                            "Skipping file-level key '%s': sir has no load_dataset()",
-                            v,
-                        )
-                        continue
+                    # Load the backing file and extract inner fraction columns.
                     try:
                         inner_ds = sir.load_dataset(v)
                     except KeyError:
-                        logger.debug(
-                            "load_dataset('%s') raised KeyError; skipping",
+                        logger.warning(
+                            "SIR inconsistency: variable '%s' found in data_vars but "
+                            "load_dataset() raised KeyError. Skipping file-level expansion.",
                             v,
                         )
                         continue
@@ -1556,23 +1553,21 @@ class PywatershedDerivation:
                             )
                             continue
                         class_codes.append(inner_code)
-                        valid_vars.append(inner_name)
+                        fractions_list.append(inner_ds[inner_name].values)
                 else:
                     class_codes.append(code)
-                    valid_vars.append(v)
+                    fractions_list.append(sir[v].values)
 
             if len(class_codes) < 2:
+                if fraction_vars:
+                    logger.debug(
+                        "Found %d variable(s) matching prefix '%s' but only %d "
+                        "valid class codes extracted; need at least 2.",
+                        len(fraction_vars),
+                        prefix,
+                        len(class_codes),
+                    )
                 continue
-
-            # Stack fractions into (nhru, n_classes) array.
-            # Values come from the inner dataset when file-level keys were
-            # expanded, otherwise directly from the SIR.
-            fractions_list: list[np.ndarray] = []
-            for v in valid_vars:
-                if inner_ds is not None and v in inner_ds:
-                    fractions_list.append(inner_ds[v].values)
-                else:
-                    fractions_list.append(sir[v].values)
 
             fractions = np.column_stack(fractions_list)
             codes = np.array(class_codes)
@@ -1581,7 +1576,7 @@ class PywatershedDerivation:
 
             logger.info(
                 "Computed majority class from %d categorical fraction columns (prefix=%r)",
-                len(valid_vars),
+                len(class_codes),
                 prefix,
             )
             return majority_class
@@ -1599,7 +1594,8 @@ class PywatershedDerivation:
 
         Classify soil texture into PRMS ``soil_type`` and derive
         ``soil_moist_max`` (maximum soil moisture capacity) from
-        available water capacity (AWC).
+        available water capacity (``awc_mm_mean``) or, as a fallback,
+        available water storage (``aws0_100_cm_mean``).
 
         Supports two input modes for soil texture:
 
@@ -1629,8 +1625,13 @@ class PywatershedDerivation:
 
         Notes
         -----
-        Unit conversions: AWC from mm -> inches (``convert(mm, in)``).
-        ``soil_moist_max`` is clipped to ``[0.5, 20.0]`` inches.
+        Unit conversions for ``soil_moist_max``:
+
+        - ``awc_mm_mean``: mm -> inches via ``convert(mm, in)``.
+        - ``aws0_100_cm_mean`` (fallback): cm -> mm (* 10) -> inches via
+          ``convert(mm, in)``.
+
+        ``soil_moist_max`` is clipped to ``[0.5, 20.0]`` inches in both cases.
 
         ``soil_rechr_max_frac`` is set to a constant default of 0.4
         (no soil layer depth data is currently available from the SIR

--- a/src/hydro_param/sir_accessor.py
+++ b/src/hydro_param/sir_accessor.py
@@ -21,6 +21,7 @@ hydro_param.plugins.DerivationContext : Consumer of SIRAccessor.
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
 
 import pandas as pd
@@ -312,7 +313,11 @@ class SIRAccessor:
         try:
             df = pd.read_csv(path, index_col=0)
         except Exception as exc:
-            raise OSError(f"Failed to read SIR file for '{name}' at {path}: {exc}.") from exc
+            raise OSError(
+                f"Failed to read SIR file for '{name}' at {path}: {exc}. "
+                f"The file may be corrupt or truncated. "
+                f"Re-run 'hydro-param run pipeline.yml' to regenerate."
+            ) from exc
         return xr.Dataset.from_dataframe(df)
 
     def find_variable(self, base_name: str) -> str | None:
@@ -332,14 +337,19 @@ class SIRAccessor:
         str or None
             The actual SIR variable name, or ``None`` if not found.
         """
-        import re
-
         if base_name in self._static:
             return base_name
         pattern = re.compile(rf"^{re.escape(base_name)}_(\d{{4}})$")
         matches = [v for v in self._static if pattern.match(v)]
         if matches:
-            return sorted(matches)[-1]
+            resolved = sorted(matches)[-1]
+            logger.debug(
+                "Resolved '%s' to year-suffixed variant '%s' (%d candidate(s))",
+                base_name,
+                resolved,
+                len(matches),
+            )
+            return resolved
         return None
 
 

--- a/tests/test_pywatershed_derivation.py
+++ b/tests/test_pywatershed_derivation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import geopandas as gpd
@@ -70,7 +71,6 @@ class _MockSIRAccessor:
 
     def find_variable(self, base_name: str) -> str | None:
         """Find variable by base name, allowing year suffixes."""
-        import re
 
         if base_name in self._ds:
             return base_name
@@ -1395,6 +1395,58 @@ class TestCategoricalFractionMajority:
         result = derivation._compute_majority_from_fractions(sir)
         assert result is not None
         np.testing.assert_array_equal(result, [41, 42])
+
+    def test_majority_from_fractions_multi_year_file_keys(
+        self, derivation: PywatershedDerivation
+    ) -> None:
+        """Multiple year-suffixed file keys don't overwrite each other.
+
+        Regression test for the inner_ds overwrite bug: when both
+        lndcov_frac_2020 and lndcov_frac_2021 exist, fractions from
+        both years must be collected correctly.
+        """
+        inner_2020 = xr.Dataset(
+            {
+                "lndcov_frac_2020_11": ("nhm_id", np.array([0.9, 0.1])),
+                "lndcov_frac_2020_41": ("nhm_id", np.array([0.1, 0.9])),
+            },
+            coords={"nhm_id": [1, 2]},
+        )
+        inner_2021 = xr.Dataset(
+            {
+                "lndcov_frac_2021_11": ("nhm_id", np.array([0.8, 0.2])),
+                "lndcov_frac_2021_41": ("nhm_id", np.array([0.2, 0.8])),
+            },
+            coords={"nhm_id": [1, 2]},
+        )
+        outer_ds = xr.Dataset(
+            {
+                "lndcov_frac_2020": ("nhm_id", np.array([0.0, 0.0])),
+                "lndcov_frac_2021": ("nhm_id", np.array([0.0, 0.0])),
+            },
+            coords={"nhm_id": [1, 2]},
+        )
+
+        class _MultiYearMock(_MockSIRAccessor):
+            def __init__(self) -> None:
+                super().__init__(outer_ds)
+                self._inners = {
+                    "lndcov_frac_2020": inner_2020,
+                    "lndcov_frac_2021": inner_2021,
+                }
+
+            def load_dataset(self, name: str) -> xr.Dataset:
+                if name in self._inners:
+                    return self._inners[name]
+                raise KeyError(name)
+
+        sir = _MultiYearMock()
+        result = derivation._compute_majority_from_fractions(sir)
+        assert result is not None
+        # 4 fraction columns total (2020_11, 2020_41, 2021_11, 2021_41).
+        # HRU 1: max fraction is 2020_11=0.9 -> class 11.
+        # HRU 2: max fraction is 2020_41=0.9 -> class 41.
+        np.testing.assert_array_equal(result, [11, 41])
 
 
 # ------------------------------------------------------------------

--- a/tests/test_sir_accessor.py
+++ b/tests/test_sir_accessor.py
@@ -265,6 +265,34 @@ def test_find_variable_year_suffix(tmp_path: Path) -> None:
     assert sir.find_variable("fctimp_pct_mean") == "fctimp_pct_mean_2021"
 
 
+def test_find_variable_picks_most_recent_year(tmp_path: Path) -> None:
+    """find_variable returns the most recent year when multiple matches exist."""
+    import textwrap
+
+    from hydro_param.sir_accessor import SIRAccessor
+
+    sir_dir = tmp_path / "sir"
+    sir_dir.mkdir()
+    df = pd.DataFrame({"val": [5.0]}, index=pd.Index([1], name="nhm_id"))
+    for year in [2019, 2021, 2020]:
+        df.to_csv(sir_dir / f"fctimp_pct_mean_{year}.csv")
+    manifest_content = textwrap.dedent("""\
+        version: 2
+        fabric_fingerprint: test
+        entries: {}
+        sir:
+          static_files:
+            fctimp_pct_mean_2019: sir/fctimp_pct_mean_2019.csv
+            fctimp_pct_mean_2020: sir/fctimp_pct_mean_2020.csv
+            fctimp_pct_mean_2021: sir/fctimp_pct_mean_2021.csv
+          temporal_files: {}
+          sir_schema: []
+    """)
+    (tmp_path / ".manifest.yml").write_text(manifest_content)
+    sir = SIRAccessor(tmp_path)
+    assert sir.find_variable("fctimp_pct_mean") == "fctimp_pct_mean_2021"
+
+
 def test_find_variable_not_found(tmp_path: Path) -> None:
     """find_variable returns None when no match exists."""
     import textwrap


### PR DESCRIPTION
## Summary

- Add `load_dataset()` and `find_variable()` methods to `SIRAccessor` for multi-column CSV loading and year-suffix matching
- Fix `_compute_majority_from_fractions` to handle file-level SIR keys (e.g., `lndcov_frac_2021`) by loading inner columns via `load_dataset()`
- Fix `_derive_landcover` to find year-suffixed `fctimp_pct_mean_2021` via `find_variable()`
- Fix `_derive_soils` to fall back to `aws0_100_cm_mean` with cm→mm unit conversion when `awc_mm_mean` is absent

Closes #119

## Impact

DRB e2e output goes from **71 → 80 parameters**. Nine previously missing parameters now derive correctly:

| Parameter | Source |
|-----------|--------|
| `cov_type` | NLCD majority class from `lndcov_frac_2021` |
| `covden_sum` | Lookup from `cov_type` |
| `covden_win` | Winter reduction of `covden_sum` |
| `hru_percent_imperv` | `fctimp_pct_mean_2021` / 100 |
| `srain_intcp` | Lookup from `cov_type` (step 8 cascade) |
| `wrain_intcp` | Lookup from `cov_type` (step 8 cascade) |
| `snow_intcp` | Lookup from `cov_type` (step 8 cascade) |
| `imperv_stor_max` | Default from step 8 (cascade) |
| `soil_moist_max` | `aws0_100_cm_mean` × 10 → mm → inches |

Calibration seed `carea_max` now uses real `hru_percent_imperv` instead of default.

## Test plan

- [x] 4 new `test_sir_accessor.py` tests for `load_dataset()` and `find_variable()`
- [x] 1 new test for file-level key majority computation
- [x] 1 new test for year-suffixed `fctimp_pct_mean_2021`
- [x] 1 new test for `aws0_100_cm_mean` fallback with unit conversion
- [x] 698 total tests passing, all checks green (`pixi run -e dev check`)
- [x] Manual DRB e2e verification: 80 parameters written to `parameters.nc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)