### PR TITLE
fix: temporal forcing detection for per-variable SIR files (#126)

### DIFF
--- a/src/hydro_param/derivations/pywatershed.py
+++ b/src/hydro_param/derivations/pywatershed.py
@@ -2351,6 +2351,25 @@ class PywatershedDerivation:
     # Step 7: Forcing generation (temporal merge)
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _concat_temporal_chunks(chunks: list[xr.Dataset]) -> xr.Dataset:
+        """Sort and concatenate multi-year temporal chunks along time.
+
+        Parameters
+        ----------
+        chunks : list[xr.Dataset]
+            One or more single-year temporal datasets to concatenate.
+
+        Returns
+        -------
+        xr.Dataset
+            Concatenated dataset sorted by time.
+        """
+        if len(chunks) > 1:
+            chunks.sort(key=lambda c: c["time"].values[0])
+            return xr.concat(chunks, dim="time")
+        return chunks[0]
+
     def _build_sir_to_forcing_lookup(
         self,
         tables_dir: Path,
@@ -2385,7 +2404,26 @@ class PywatershedDerivation:
         lookup: dict[str, dict[str, str]] = {}
         for source_name, variables in datasets_config.items():
             for prms_name, var_cfg in variables.items():
+                for required_key in ("sir_name", "sir_unit", "intermediate_unit"):
+                    if required_key not in var_cfg:
+                        raise ValueError(
+                            f"forcing_variables.yml: source '{source_name}', "
+                            f"variable '{prms_name}' is missing required key "
+                            f"'{required_key}'. Available keys: "
+                            f"{list(var_cfg.keys())}"
+                        )
                 sir_name = var_cfg["sir_name"]
+                if sir_name in lookup:
+                    logger.warning(
+                        "Duplicate SIR name '%s' in forcing_variables.yml: "
+                        "source '%s' (prms_name='%s') overwrites source '%s' "
+                        "(prms_name='%s').",
+                        sir_name,
+                        source_name,
+                        prms_name,
+                        lookup[sir_name]["source"],
+                        lookup[sir_name]["prms_name"],
+                    )
                 lookup[sir_name] = {
                     "prms_name": prms_name,
                     "sir_unit": var_cfg["sir_unit"],
@@ -2404,7 +2442,7 @@ class PywatershedDerivation:
         Look up each per-variable temporal dataset in the reverse mapping
         from ``forcing_variables.yml``, rename to PRMS conventions
         (e.g., ``tmmx_C_mean`` -> ``tmax``), apply unit conversions
-        (e.g., W/m² -> langleys, mm -> inches), and merge time-series
+        (e.g., W/m² -> Langleys/day, mm -> inches), and merge time-series
         arrays into the parameter dataset.
 
         Multi-year temporal chunks (keyed with ``_YYYY`` suffixes like
@@ -2469,12 +2507,7 @@ class PywatershedDerivation:
             sir_unit = var_cfg["sir_unit"]
             intermediate_unit = var_cfg["intermediate_unit"]
 
-            # Concat multi-year chunks
-            if len(chunks) > 1:
-                chunks.sort(key=lambda c: c["time"].values[0])
-                merged = xr.concat(chunks, dim="time")
-            else:
-                merged = chunks[0]
+            merged = self._concat_temporal_chunks(chunks)
 
             if var_base not in merged:
                 logger.warning(
@@ -2515,6 +2548,15 @@ class PywatershedDerivation:
 
         if forced_count > 0:
             logger.info("Step 7: merged %d forcing variables.", forced_count)
+        else:
+            logger.warning(
+                "Step 7: temporal data contained %d variable(s) but none "
+                "matched forcing config. Expected SIR names: %s. "
+                "Received: %s.",
+                len(chunks_by_var),
+                sorted(sir_lookup.keys()),
+                sorted(chunks_by_var.keys()),
+            )
 
         return ds
 
@@ -2550,9 +2592,9 @@ class PywatershedDerivation:
         -----
         Temperature conversion: °C -> °F via ``T_f = T_c * 9/5 + 32``.
 
-        Requires full 12-month coverage in the temporal data to produce
-        reliable normals.  Sources with fewer than 12 months are skipped
-        with a warning.
+        Requires full 12-month coverage in both tmax and tmin temporal
+        data to produce reliable normals.  Returns ``None`` with a
+        warning if either variable covers fewer than 12 months.
 
         For single-HRU datasets, the output is reshaped from ``(12,)``
         to ``(12, 1)`` to maintain consistent 2-D array shape.
@@ -2564,13 +2606,9 @@ class PywatershedDerivation:
         sir_lookup = self._build_sir_to_forcing_lookup(tables_dir)
 
         # Find tmax and tmin SIR names from config
-        tmax_sir: str | None = None
-        tmin_sir: str | None = None
-        for sir_name, cfg in sir_lookup.items():
-            if cfg["prms_name"] == "tmax":
-                tmax_sir = sir_name
-            elif cfg["prms_name"] == "tmin":
-                tmin_sir = sir_name
+        prms_to_sir = {cfg["prms_name"]: sn for sn, cfg in sir_lookup.items()}
+        tmax_sir = prms_to_sir.get("tmax")
+        tmin_sir = prms_to_sir.get("tmin")
 
         if tmax_sir is None or tmin_sir is None:
             logger.warning(
@@ -2593,18 +2631,8 @@ class PywatershedDerivation:
             logger.warning("No tmax/tmin variables found in temporal data for climate normals.")
             return None
 
-        # Concat multi-year chunks
-        if len(tmax_chunks) > 1:
-            tmax_chunks.sort(key=lambda c: c["time"].values[0])
-            tmax_merged = xr.concat(tmax_chunks, dim="time")
-        else:
-            tmax_merged = tmax_chunks[0]
-
-        if len(tmin_chunks) > 1:
-            tmin_chunks.sort(key=lambda c: c["time"].values[0])
-            tmin_merged = xr.concat(tmin_chunks, dim="time")
-        else:
-            tmin_merged = tmin_chunks[0]
+        tmax_merged = self._concat_temporal_chunks(tmax_chunks)
+        tmin_merged = self._concat_temporal_chunks(tmin_chunks)
 
         if tmax_sir not in tmax_merged or tmin_sir not in tmin_merged:
             logger.warning(
@@ -2614,17 +2642,20 @@ class PywatershedDerivation:
             )
             return None
 
-        # Group by month, compute mean, convert C -> F
+        # Group by month and compute mean
         tmax_monthly = tmax_merged[tmax_sir].groupby("time.month").mean(dim="time")
         tmin_monthly = tmin_merged[tmin_sir].groupby("time.month").mean(dim="time")
 
-        # Validate full 12-month coverage
-        n_months = tmax_monthly.sizes.get("month", 0)
-        if n_months != 12:
+        # Validate full 12-month coverage for both variables
+        n_tmax_months = tmax_monthly.sizes.get("month", 0)
+        n_tmin_months = tmin_monthly.sizes.get("month", 0)
+        if n_tmax_months != 12 or n_tmin_months != 12:
             logger.warning(
-                "Temporal tmax data covers only %d of 12 months; "
-                "cannot compute reliable monthly normals. Skipping.",
-                n_months,
+                "Temporal data covers only %d (tmax) / %d (tmin) of "
+                "12 months; cannot compute reliable monthly normals. "
+                "Skipping.",
+                n_tmax_months,
+                n_tmin_months,
             )
             return None
 

--- a/tests/test_pywatershed_derivation.py
+++ b/tests/test_pywatershed_derivation.py
@@ -1628,15 +1628,16 @@ class TestForcingVariablesYAML:
 class TestBuildSirToForcingLookup:
     """Tests for _build_sir_to_forcing_lookup reverse mapping."""
 
-    def test_returns_all_five_gridmet_variables(
-        self,
-        derivation: PywatershedDerivation,
-    ) -> None:
-        """Reverse lookup contains all 5 gridmet SIR variable names."""
+    @pytest.fixture()
+    def lookup(self, derivation: PywatershedDerivation) -> dict[str, dict[str, str]]:
+        """Build the reverse lookup from the bundled forcing_variables.yml."""
         from importlib.resources import files
 
         tables_dir = Path(str(files("hydro_param").joinpath("data/pywatershed/lookup_tables")))
-        lookup = derivation._build_sir_to_forcing_lookup(tables_dir)
+        return derivation._build_sir_to_forcing_lookup(tables_dir)
+
+    def test_returns_all_five_gridmet_variables(self, lookup: dict[str, dict[str, str]]) -> None:
+        """Reverse lookup contains all 5 gridmet SIR variable names."""
         expected_sir_names = {
             "pr_mm_mean",
             "tmmx_C_mean",
@@ -1646,30 +1647,16 @@ class TestBuildSirToForcingLookup:
         }
         assert set(lookup.keys()) == expected_sir_names
 
-    def test_prms_names_correct(
-        self,
-        derivation: PywatershedDerivation,
-    ) -> None:
+    def test_prms_names_correct(self, lookup: dict[str, dict[str, str]]) -> None:
         """Each SIR name maps to the correct PRMS name."""
-        from importlib.resources import files
-
-        tables_dir = Path(str(files("hydro_param").joinpath("data/pywatershed/lookup_tables")))
-        lookup = derivation._build_sir_to_forcing_lookup(tables_dir)
         assert lookup["pr_mm_mean"]["prms_name"] == "prcp"
         assert lookup["tmmx_C_mean"]["prms_name"] == "tmax"
         assert lookup["tmmn_C_mean"]["prms_name"] == "tmin"
         assert lookup["srad_W_m2_mean"]["prms_name"] == "swrad"
         assert lookup["pet_mm_mean"]["prms_name"] == "potet"
 
-    def test_source_field_present(
-        self,
-        derivation: PywatershedDerivation,
-    ) -> None:
+    def test_source_field_present(self, lookup: dict[str, dict[str, str]]) -> None:
         """Each entry includes the source dataset name."""
-        from importlib.resources import files
-
-        tables_dir = Path(str(files("hydro_param").joinpath("data/pywatershed/lookup_tables")))
-        lookup = derivation._build_sir_to_forcing_lookup(tables_dir)
         for entry in lookup.values():
             assert entry["source"] == "gridmet"
 
@@ -1810,7 +1797,7 @@ class TestDeriveForcing:
         derivation: PywatershedDerivation,
         sir_topography: xr.Dataset,
     ) -> None:
-        """Completely unknown source with no matching variables is skipped."""
+        """Temporal variable with no matching forcing config entry is skipped."""
         temporal = {
             "unknown_source_2020": xr.Dataset(
                 {"some_unknown_var": (("time", "nhm_id"), np.ones((2, 3)))},


### PR DESCRIPTION
## Summary

- Add `_build_sir_to_forcing_lookup()` reverse mapping from SIR variable names to forcing config, enabling per-variable temporal data lookup without requiring all variables in a single dataset
- Refactor `_derive_forcing()` to iterate per-variable instead of per-source, eliminating ~25 spurious warnings per run
- Refactor `_compute_monthly_normals()` to find tmax and tmin independently, fixing climate normals computation that was broken with per-variable SIR files (PET and transpiration now use climate-derived values instead of scalar defaults)
- Delete `_detect_forcing_dataset()` (56 lines) — no longer needed with per-variable reverse lookup

Closes #126

## Test Plan
- [x] All 701 tests pass (`pixi run -e dev check`)
- [x] All pre-commit hooks pass
- [x] 3 new tests for `_build_sir_to_forcing_lookup` (covers all 5 variables, PRMS name mapping, source field)
- [x] All inline temporal dicts in tests updated from source-keyed (`gridmet_2020`) to variable-keyed (`pr_mm_mean_2020`) format
- [x] `temporal_gridmet` fixture updated to match real SIR per-variable-per-year output
- [ ] End-to-end verification with DRB test data

🤖 Generated with [Claude Code](https://claude.com/claude-code)