### PR TITLE
fix: skip re-downloading extracted zip files in GFv1.1 download

### DIFF
--- a/src/hydro_param/gfv11.py
+++ b/src/hydro_param/gfv11.py
@@ -116,7 +116,7 @@ class DownloadSummary:
     downloaded : list[str]
         Filenames successfully downloaded.
     skipped : list[str]
-        Filenames skipped (already existed on disk).
+        Filenames skipped (already existed on disk or already extracted).
     failed : list[str]
         Filenames that failed after exhausting retries.
     extract_failed : list[str]
@@ -404,6 +404,9 @@ def download_item(item_id: str, output_dir: Path) -> DownloadSummary:
     Notes
     -----
     Existing files are not re-downloaded (see :func:`download_file`).
+    For zip archives, a ``.zip.done`` marker file is written after
+    successful extraction; on subsequent runs, files with an existing
+    marker are skipped without contacting the server.
     Download failures are accumulated and reported in the summary rather
     than stopping the entire batch.
     """
@@ -436,8 +439,15 @@ def download_item(item_id: str, output_dir: Path) -> DownloadSummary:
         if downloaded:
             summary.downloaded.append(name)
             if name.lower().endswith(".zip"):
+                assert marker is not None  # zip guard above guarantees this
                 if _unzip_and_clean(dest, dest.parent):
-                    marker.touch()  # type: ignore[union-attr]
+                    try:
+                        marker.touch()
+                    except OSError:
+                        logger.warning(
+                            "Could not write marker %s — file will be re-downloaded on next run",
+                            marker.name,
+                        )
                 else:
                     summary.extract_failed.append(name)
         else:

--- a/tests/test_gfv11.py
+++ b/tests/test_gfv11.py
@@ -479,6 +479,95 @@ class TestDownloadItem:
         assert summary.downloaded == ["dem.zip"]
         assert summary.extract_failed == ["dem.zip"]
 
+    @patch("hydro_param.gfv11._unzip_and_clean")
+    @patch("hydro_param.gfv11.download_file")
+    @patch("hydro_param.gfv11.fetch_item_files")
+    def test_creates_marker_after_successful_extraction(
+        self,
+        mock_fetch: MagicMock,
+        mock_dl: MagicMock,
+        mock_unzip: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """A .zip.done marker is created after successful zip extraction."""
+        mock_fetch.return_value = [
+            ("dem.zip", "https://example.com/dem.zip", 100),
+        ]
+        mock_dl.return_value = True
+        mock_unzip.return_value = True
+        # download_file is mocked, so create the parent directory manually
+        (tmp_path / "topo").mkdir(parents=True)
+
+        download_item("fake-id", tmp_path)
+
+        marker = tmp_path / "topo" / "dem.zip.done"
+        assert marker.exists()
+
+    @patch("hydro_param.gfv11._unzip_and_clean")
+    @patch("hydro_param.gfv11.download_file")
+    @patch("hydro_param.gfv11.fetch_item_files")
+    def test_no_marker_after_failed_extraction(
+        self,
+        mock_fetch: MagicMock,
+        mock_dl: MagicMock,
+        mock_unzip: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """No marker is created when zip extraction fails."""
+        mock_fetch.return_value = [
+            ("dem.zip", "https://example.com/dem.zip", 100),
+        ]
+        mock_dl.return_value = True
+        mock_unzip.return_value = False
+
+        download_item("fake-id", tmp_path)
+
+        marker = tmp_path / "topo" / "dem.zip.done"
+        assert not marker.exists()
+
+    @patch("hydro_param.gfv11.download_file")
+    @patch("hydro_param.gfv11.fetch_item_files")
+    def test_skips_download_when_marker_exists(
+        self,
+        mock_fetch: MagicMock,
+        mock_dl: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Files with an existing .zip.done marker are skipped entirely."""
+        mock_fetch.return_value = [
+            ("dem.zip", "https://example.com/dem.zip", 100),
+        ]
+        # Create the marker file
+        marker_dir = tmp_path / "topo"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / "dem.zip.done").touch()
+
+        summary = download_item("fake-id", tmp_path)
+
+        mock_dl.assert_not_called()
+        assert summary.skipped == ["dem.zip"]
+
+    @patch("hydro_param.gfv11._unzip_and_clean")
+    @patch("hydro_param.gfv11.download_file")
+    @patch("hydro_param.gfv11.fetch_item_files")
+    def test_no_marker_for_non_zip_files(
+        self,
+        mock_fetch: MagicMock,
+        mock_dl: MagicMock,
+        mock_unzip: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Non-zip files do not produce marker files."""
+        mock_fetch.return_value = [
+            ("CrossWalk.xlsx", "https://example.com/CrossWalk.xlsx", 50),
+        ]
+        mock_dl.return_value = True
+
+        download_item("fake-id", tmp_path)
+
+        # No .done marker for non-zip files
+        assert not (tmp_path / "metadata" / "CrossWalk.xlsx.done").exists()
+
 
 # ---------------------------------------------------------------------------
 # download_gfv11


### PR DESCRIPTION
## Summary
- Write a `.zip.done` marker file after successful zip extraction in `download_item()`
- Check for marker before attempting download, skipping already-extracted archives
- Fixes re-download of every zip on subsequent runs (zip is deleted after extraction, so the existing file-exists check never triggers)

Closes #180

## Test plan
- [ ] Run `hydro-param gfv11 download --output-dir <dir>` — files download and extract normally
- [ ] Re-run the same command — all zips are skipped with "already extracted" log message
- [ ] Delete a `.zip.done` marker and re-run — only that file re-downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)