### PR TITLE
fix: prevent gfv11 overlay clobber by tests and partial downloads

### DIFF
--- a/src/hydro_param/gfv11.py
+++ b/src/hydro_param/gfv11.py
@@ -965,6 +965,9 @@ def download_gfv11(
         raise DownloadError(
             f"{len(combined.failed)} download(s) and "
             f"{len(combined.extract_failed)} extraction(s) failed. "
+            f"Successfully downloaded files are in {output_dir} but were NOT "
+            f"registered. Re-run the download to retry failed files, or call "
+            f"write_registry_overlay() manually after resolving failures. "
             f"See log output above for details."
         )
 

--- a/tests/test_gfv11.py
+++ b/tests/test_gfv11.py
@@ -804,6 +804,10 @@ class TestDownloadGfv11:
         with pytest.raises(DownloadError, match="1 extraction"):
             download_gfv11(tmp_path, items="data-layers", overlay_path=overlay_path)
 
+        # Overlay must NOT be written when there are failures, even if some
+        # files were successfully downloaded.
+        assert not overlay_path.exists()
+
 
 # ---------------------------------------------------------------------------
 # Auto-registration after download


### PR DESCRIPTION
## Summary
- Test `test_raises_on_extract_failures` wrote to real `~/.hydro-param/datasets/gfv11.yml` with pytest temp paths, clobbering the user's valid overlay. Fixed by passing explicit `overlay_path`.
- `download_gfv11()` wrote the registry overlay before checking for failures, so partial downloads could register incomplete data. Moved overlay write to after the failure check.

Closes #190

## Test plan
- [x] All 954 tests pass
- [x] `pixi run -e dev check` passes
- [x] Verified overlay survives full test run without being clobbered

🤖 Generated with [Claude Code](https://claude.com/claude-code)