### PR TITLE
fix: map gdptools 50% percentile column to median statistic name

### DIFF
--- a/src/hydro_param/processing.py
+++ b/src/hydro_param/processing.py
@@ -46,6 +46,13 @@ logger = logging.getLogger(__name__)
 
 ZonalEngine = Literal["serial", "parallel", "dask", "exactextract"]
 
+# gdptools/exactextract returns percentile columns as "25%", "50%", "75%"
+# but users request them as "median".  This mapping normalizes column names
+# so that user-facing statistic names work transparently.
+_STAT_COLUMN_RENAMES: dict[str, str] = {
+    "50%": "median",
+}
+
 
 class Processor(Protocol):
     """Protocol defining the interface for spatial processing strategies.
@@ -223,6 +230,8 @@ class ZonalProcessor:
 
         # For continuous variables, validate and select requested statistics
         if not categorical:
+            # Normalize gdptools percentile column names (e.g., "50%" → "median")
+            result_df = result_df.rename(columns=_STAT_COLUMN_RENAMES)
             available = set(result_df.columns)
             missing = [s for s in statistics if s not in available]
             if missing:
@@ -356,6 +365,8 @@ class ZonalProcessor:
 
         # For continuous variables, validate and select requested statistics
         if not categorical:
+            # Normalize gdptools percentile column names (e.g., "50%" → "median")
+            result_df = result_df.rename(columns=_STAT_COLUMN_RENAMES)
             available = set(result_df.columns)
             missing = [s for s in statistics if s not in available]
             if missing:


### PR DESCRIPTION
## Summary
- Add `_STAT_COLUMN_RENAMES` mapping (`50%` → `median`) in `processing.py`
- Apply rename in both `ZonalProcessor.process()` and `process_nhgf_stac()` before statistic selection
- Users can now request `statistic: median` in pipeline configs and get the correct values

Closes #209

## Test plan
- [x] 35 processing/pipeline tests passing
- [ ] Run pipeline with `statistics: [mean, median]` — verify median column appears in SIR output

🤖 Generated with [Claude Code](https://claude.com/claude-code)