### PR TITLE
fix: compute segment centroid in projected CRS

### DIFF
--- a/src/hydro_param/derivations/pywatershed.py
+++ b/src/hydro_param/derivations/pywatershed.py
@@ -939,7 +939,7 @@ class PywatershedDerivation:
             )
             seg_lats = segments.geometry.centroid.y.values
         else:
-            segs_5070 = segments if segments.crs == "EPSG:5070" else segments.to_crs(epsg=5070)
+            segs_5070 = segments.to_crs(epsg=5070)
             seg_centroids_4326 = gpd.GeoSeries(segs_5070.geometry.centroid, crs="EPSG:5070").to_crs(
                 epsg=4326
             )

--- a/tests/test_pywatershed_derivation.py
+++ b/tests/test_pywatershed_derivation.py
@@ -1593,8 +1593,43 @@ class TestDeriveTopology:
         assert "seg_lat" in ds
         assert ds["seg_lat"].dims == ("nsegment",)
         # synthetic_segments are in EPSG:5070 near DRB (~41.8°N)
-        assert ds["seg_lat"].dims == ("nsegment",)
         np.testing.assert_allclose(ds["seg_lat"].values, [41.81, 41.79, 41.77], atol=0.1)
+
+    def test_seg_lat_no_crs_fallback(
+        self,
+        derivation: PywatershedDerivation,
+        sir_minimal: _MockSIRAccessor,
+        synthetic_fabric: gpd.GeoDataFrame,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """seg_lat falls back to raw centroid when segments have no CRS."""
+        import logging
+
+        segs_no_crs = gpd.GeoDataFrame(
+            {
+                "nhm_seg": [201, 202, 203],
+                "tosegment": [2, 3, 0],
+            },
+            geometry=[
+                LineString([(0, 40.0), (1, 40.0)]),
+                LineString([(1, 40.0), (2, 40.0)]),
+                LineString([(2, 40.0), (3, 40.0)]),
+            ],
+            crs=None,
+        )
+        ctx = DerivationContext(
+            sir=sir_minimal,
+            fabric=synthetic_fabric,
+            segments=segs_no_crs,
+            fabric_id_field="nhm_id",
+            segment_id_field="nhm_seg",
+        )
+        with caplog.at_level(logging.WARNING, logger="hydro_param.derivations.pywatershed"):
+            ds = derivation.derive(ctx)
+        assert "seg_lat" in ds
+        # Raw centroid y values (no projection)
+        np.testing.assert_allclose(ds["seg_lat"].values, [40.0, 40.0, 40.0], atol=0.01)
+        assert "Segments have no CRS" in caplog.text
 
 
 class TestTopologyValidation:


### PR DESCRIPTION
## Summary
- Project segments to EPSG:5070 before computing centroids for `seg_lat`, then reproject to EPSG:4326 for latitude extraction
- Eliminates the GeoPandas warning: "Geometry is in a geographic CRS. Results from 'centroid' are likely incorrect"
- Mirrors the HRU `representative_point()` approach already used in `_derive_geometry()`
- Updates `synthetic_segments` test fixture to use EPSG:5070 with realistic DRB-area coordinates

Closes #213

## Test plan
- [x] All 1014 tests pass
- [x] `seg_lat` values verified against manual EPSG:5070→4326 coordinate conversion
- [ ] Run `hydro-param pywatershed run` with GFv1.1 config and verify no centroid warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)