### PR TITLE
fix: use circular mean aspect (sin/cos) in example configs

### DIFF
--- a/configs/examples/drb_2yr_pipeline.yml
+++ b/configs/examples/drb_2yr_pipeline.yml
@@ -14,9 +14,9 @@ target_fabric:
 
 datasets:
   topography:
-    # 3DEP 10m DEM — elevation, slope, aspect
+    # 3DEP 10m DEM — elevation, slope, sin/cos aspect for circular mean
     - name: dem_3dep_10m
-      variables: [elevation, slope, aspect]
+      variables: [elevation, slope, sin_aspect, cos_aspect]
       statistics: [mean]
 
   soils:

--- a/configs/examples/drb_2yr_pywatershed.yml
+++ b/configs/examples/drb_2yr_pywatershed.yml
@@ -38,12 +38,6 @@ static_datasets:
       variable: slope
       statistic: mean
       description: "Mean land surface slope"
-    hru_aspect:
-      source: dem_3dep_10m
-      variable: aspect
-      statistic: mean
-      description: "Mean HRU aspect"
-
   soils:
     available: [polaris_30m, gnatsgo_rasters]
     soil_type:

--- a/configs/examples/gfv11_static_pipeline.yml
+++ b/configs/examples/gfv11_static_pipeline.yml
@@ -23,7 +23,7 @@ datasets:
   topography:
     # 3DEP 1 arc-second (~30m) DEM — comparable resolution to GFv1.1 SRTM
     - name: dem_3dep_30m
-      variables: [elevation, slope, aspect]
+      variables: [elevation, slope, sin_aspect, cos_aspect]
       statistics: [mean, median]
 
   soils:

--- a/configs/examples/gfv11_static_pywatershed.yml
+++ b/configs/examples/gfv11_static_pywatershed.yml
@@ -44,12 +44,6 @@ static_datasets:
       variable: slope
       statistic: mean
       description: "Mean land surface slope (Horn method, derived from 3DEP ~30m DEM)"
-    hru_aspect:
-      source: dem_3dep_30m
-      variable: aspect
-      statistic: mean
-      description: "Mean HRU aspect (Horn method, derived from 3DEP ~30m DEM)"
-
   soils:
     available: [gfv11_sand, gfv11_silt, gfv11_clay, gfv11_awc, gfv11_text_prms]
     soil_type:


### PR DESCRIPTION
## Summary
- Pipeline configs: `aspect` → `sin_aspect, cos_aspect` for correct circular mean aggregation
- Pywatershed configs: remove `hru_aspect` entry — derivation reads sin/cos directly from SIR via `atan2(sin_mean, cos_mean)`
- Affects all 4 example configs (GFv1.1 pipeline/pywatershed, DRB 2yr pipeline/pywatershed)

Closes #215

## Test plan
- [x] Config-only change — no code modified
- [ ] Re-run pipeline with updated config to produce `sin_aspect_mean` and `cos_aspect_mean` in SIR
- [ ] Verify pywatershed run uses circular mean path (no legacy aspect warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)